### PR TITLE
add: エラーダイアログの表示を追加

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6,5 +6,8 @@
   "repositoryNotFound": "Repository not found",
   "repositoryDetail": "Repository Detail",
   "openGitHub": "Open GitHub",
-  "noDescription"  :"No repository description"
+  "noDescription"  :"No repository description",
+  "err": "Error",
+  "errMessage": "The URL could not be opened.",
+  "close": "Close"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -6,5 +6,9 @@
   "repositoryNotFound": "リポジトリが見つかりませんでした",
   "repositoryDetail": "リポジトリ詳細",
   "openGitHub": "GitHubを開く",
-  "noDescription" : "リポジトリの説明がありません"
+  "noDescription" : "リポジトリの説明がありません",
+  "err": "エラー",
+  "errMessage": "URLを開けませんでした。",
+  "close": "閉じる"
+
 }

--- a/lib/pages/repository_detail_page/repository_detail_page.dart
+++ b/lib/pages/repository_detail_page/repository_detail_page.dart
@@ -137,6 +137,28 @@ class RepositoryDetailPage extends StatelessWidget {
         if (await canLaunchUrl(url)) {
           await launchUrl(url);
         } else {
+          showDialog(
+            context: context,
+            builder: (BuildContext context) {
+              return AlertDialog(
+                title: Text(AppLocalizations.of(context)!.err),
+                content: Text(AppLocalizations.of(context)!.errMessage),
+                actions: <Widget>[
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                    },
+                    child: Text(
+                      AppLocalizations.of(context)!.close,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.tertiary,
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+          );
           throw 'Could not launch $url';
         }
       },


### PR DESCRIPTION
### 関連チケット
#24 

### やったこと
- エラー発生時にユーザーに通知するため、エラーダイアログを追加
- ダイアログ内のテキストとボタンはAppLocalizationsを使用して多言語対応
- ボタンのスタイルはテーマカラーを適用